### PR TITLE
refactored configuration structure for code splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,185 +1,81 @@
 # Skeletor Rollup Plugin
 [![Build Status](https://travis-ci.org/deg-skeletor/skeletor-plugin-rollup.svg?branch=master)](https://travis-ci.org/deg-skeletor/skeletor-plugin-rollup)
 
-The purpose of this plugin is to bundle modules together using rollup.
+The purpose of this plugin is to bundle modules together using [Rollup](https://rollupjs.org). This plugin is part of the Skeletor ecosystem. To learn more about Skeletor, [go here](https://github.com/deg-skeletor/skeletor-core).
 
-This is a functioning plugin that can be installed as-is to a Skeletor-equipped project. 
+## Installation
+Install this plugin into your Skeletor-equipped project via the following terminal command: 
+```
+    npm install --save-dev @deg-skeletor/plugin-rollup
+```
 
-To learn more about Skeletor, [go here](https://github.com/deg-skeletor/skeletor-core).
+## Configuration
 
-## Getting Started
-After you have cloned this repository, run `npm install` in a terminal to install some necessary tools, including a testing framework (Jest) and a linter (ESLint). 
+The configuration for this plugin mimics the standard configuration patterns for Rollup (learn more [here](https://rollupjs.org/guide/en#configuration-files)).
 
-## Source Code
-The primary source code for this sample plugin is located in the `index.js` file.
-
-## Running Tests
-This sample plugin is pre-configured with the [Jest testing framework](https://facebook.github.io/jest/) and an example test. 
-
-From a terminal, run `npm test`. You should see one test pass and feel pleased.
-
-Test code can be found in the `index.test.js` file.
-
-## Skeletor Plugin API
-
-For a Skeletor plugin to function within the Skeletor ecosystem, it must expose a simple API that the Skeletor task runner will interact with.
-The method signatures of the API are as follows:
-
-### run(config)
-
-The `run()` method executes a plugin's primary task,. It is the primary way (and, currently, the *only* way) that the Skeletor task runner interacts with a plugin.
-
-## Config Options
-
-Example:
+### Example Configuration - Single Bundle
 ```
 {
-    bundles: [{
-        input: {
-            entry: "source/js/main.js"
-        },        
-        output: [{
+    
+    input: "source/js/main.js",        
+    output: [
+        {
             file: "dist/js/main-bundle.js",
             format: "es"
+        },
+        {
+            file: "dist/js/main-bundle-nomodule.js",
+            format: "system"
+        }
+    ],
+    plugins: [
+        require('rollup-plugin-babel')({
+            exclude: 'node_modules/**'
+        }),
+        require('rollup-plugin-node-resolve')({
+            browser: true
+        }),
+        require('rollup-plugin-commonjs')()
+    ]
+}
+```
+
+### Example Configuration - Multiple Bundles
+```
+[
+    {   
+        input: "source/js/entryA.js",        
+        output: [{
+            file: "dist/js/entryA-bundle.js",
+            format: "es"
         }]
+    },
+    {   
+        input: "source/js/entryB.js",        
+        output: [{
+            file: "dist/js/entryB-bundle.js",
+            format: "es"
+        }]
+    }
+]
+```
+
+### Example Configuration - Multiple Bundles With Code Splitting
+```
+{
+    input: ["source/js/entryA.js", "source/js/entryB.js"],        
+    output: [
+        {
+            dir: "dist/js",
+            format: "es"
+        },
+        {
+            dir: "dist/js/nomodule",
+            format: "system"
+        }
     }],
-    rollupPlugins: [
-        {
-            module: require('rollup-plugin-babel'),
-            pluginConfig: {
-                exclude: 'node_modules/**'   
-            }
-        },
-        {
-            module: require('rollup-plugin-node-resolve'),
-            pluginConfig: {
-                browser: true
-            }
-        },
-        {
-            module: require('rollup-plugin-commonjs')
-        }
-    ]
+    experimentalCodeSplitting: true
 }
 ```
 
-**bundles**
-
-Type: `Object[]`
-
-A list of [bundle config objects](#bundle-config-object).
-
-**rollupPlugins (optional)**
-
-Type: `Object[]`
-
-A list of [rollup plugin configs](#rollup-plugin-config-object).
-*Note*: Order of plugins does matter! Rollup plugins are executed from last to first.
-
-### Bundle Config Object
-
-Example:
-```
-{
-    bundles: [
-        {
-            input: {
-                entry: "source/js/main.js"
-            },
-            output: [{
-                fille: "dist/js/main-bundle.js",
-                format: "es"
-            }]
-        },
-        {
-            input: {
-                entry: "source/js/formHandler.js"
-            },
-            output: [
-                {
-                    file: "dist/js/formHandler-bundle.js",
-                    format: "es"
-                },
-                {
-                    file: "dist/js/formHandler-bundle-legacy.js",
-                    format: "iife"
-                }
-            ]
-        }
-    ]
-}
-```
-
-**input**
-
-Type: `Object`
-
-must have an `entry` property. Also holds any other input configurations supported by [rollup](https://rollupjs.org/guide/en#command-line-reference).
-
-**input.entry**
-
-Type: `String`
-
-Path to entry point for bundle. This path is from the root of the project.
-
-**output**
-
-Type: `Object[]`
-
-Describes the output files from rollup. This object should include properties supported by [rollup outputs](https://rollupjs.org/guide/en#big-list-of-options)
-
-If not specified, the `format` property will default to `es`.
-
-### Rollup Plugin Config Object
-
-Example:
-```
-{
-    rollupPlugins: [
-        {
-            "module": require('rollup-plugin'),
-            "pluginConfig": {}
-        }
-    ]
-}
-```
-
-**module**
-
-Type: `NPM module`
-
-An rollup plugin npm module. Check out the list of [rollup plugins](https://github.com/rollup/rollup/wiki/Plugins) for the possibilities.
-
-**pluginConfig (optional)**
-
-Type: `Object`
-Default: `{}`
-
-A config object for the corresponding plugin. Check the module's documentation for configuration options.
-
-
-## Return Value
-A Promise that resolves to a [Status object](#the-status-object).
-
-### The Status Object
-The Status object is a simple Javascript `Object` for storing the current status of your plugin. The structure of this object is as follows:
-
-#### Properties
-
-**status**
-
-Type: `String`
-
-Possible Values: `'complete'`, `'error'`
-
-Contains the status of the plugin. If the plugin has completed successfully, the `'complete'` value should be used. If an error was encountered during plugin execution, the `'error'` value should be used.
-
-**message**
-
-Type: `String`
-
-Contains any additional information regarding the status of the plugin. If the plugin executed successfully, this property could include information about what the plugin accomplished. If the plugin encountered an error, this property could include error details. 
-
-## Required Add-Ins
-[rollup](https://github.com/rollup/rollup):
-A module bundler for JavaScript.
+For a detailed list of configuration options, check out Rollup's [big list of options](https://rollupjs.org/guide/en#big-list-of-options). 

--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -2,6 +2,17 @@ function resolve(path) {
     return path;
 }
 
+function basename(path) {
+    const parts = path.split('/');
+    return parts[parts.length - 1];
+}
+
+function join(path1, path2) {
+    return path1 + '/' + path2;
+}
+
 module.exports = {
-    resolve
+    resolve,
+    basename,
+    join
 };

--- a/__mocks__/rollup.js
+++ b/__mocks__/rollup.js
@@ -1,31 +1,23 @@
-let __fakeBundle = {};
-
-const rollup = {
-    rollup: rollupFn
+let __fakeBundle = {
+    write: jest.fn(write)
 };
 
-function rollupFn(inputOpts) {
-    __fakeBundle = {
-        ...__fakeBundle,
-        input: inputOpts
-    };
-
-    return Promise.resolve({
-        write
-    });
-}
+const rollup = {
+    rollup: jest.fn(() => Promise.resolve(__fakeBundle))
+};
 
 function write(outputOpts) {
-    if (__fakeBundle.output) {
-        __fakeBundle.output.push(outputOpts);
-    } else {
-        __fakeBundle.output = [outputOpts];
-    }
     if (outputOpts.file === 'error') {
-        Promise.reject('Error: Could not resolve entry (error)');
+        return Promise.reject('Error: Could not resolve entry (error)');
     }
 
-    return Promise.resolve();
+    return Promise.resolve({
+        output: {
+            bundle: {
+                fileName: 'bundle.js'
+            }
+        }
+    });
 }
 
 function __getFakeBundle() {
@@ -33,7 +25,7 @@ function __getFakeBundle() {
 }
 
 function __clearFakeBundle() {
-    __fakeBundle = {};
+    __fakeBundle.write.mockClear();
 }
 
 rollup.__clearFakeBundle = __clearFakeBundle;

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,7 @@
 const skeletorRollup = require('./index');
+const fakeRollupPlugin = require('./__mocks__/rollup-plugin');
 
 let rollup;
-jest.mock('rollup');
 jest.mock('path');
 
 const logger = {
@@ -11,339 +11,301 @@ const logger = {
 const options = {logger};
 const logSpy = jest.spyOn(logger, 'info');
 
-describe('rollup plugin', () => {
+beforeEach(() => {
+    rollup = require('rollup');
+});
 
-    beforeEach(() => {
-        rollup = require('rollup');
-    });
+afterEach(() => {
+    rollup.__clearFakeBundle();
+    rollup.rollup.mockClear();
+    logSpy.mockReset();
+});
 
-    afterEach(() => {
-        rollup.__clearFakeBundle();
-        logSpy.mockReset();
-    });
-
-    it('should error if no bundles defined', () => {
+describe('An error should be thrown', () => {
+    it('if no input/outputs set is defined', async () => {
         const config = {};
-        const expectedErrorMessage = 'Error: No bundle configurations found.';
-        return skeletorRollup().run(config, options).catch(resp => {
-            expect(resp).toEqual(expectedErrorMessage);
-        });
+        const expectedErrorMessage = 'Error: Configuration does not have input and output properties.';
+        
+        try {
+            await skeletorRollup().run(config, options);
+        } catch(e) {
+            expect(e).toEqual(expectedErrorMessage);
+        }
     });
 
-    it('should create input options', () => {
+    it('if a bundle fails to write', async () => {
         const config = {
-            bundles: [{
-                input: {
-                    entry: 'source/test.txt',
-                    experimentalCodeSplitting: true
-                },
-                output: [{
-                    file: 'public/test.txt'
-                }]
-            }]
-        };
-        const expectedResponse = {
             input: 'source/test.txt',
-            experimentalCodeSplitting: true,
-            plugins: []
-        };
-        return skeletorRollup().run(config, options).then(() => {
-            const inputOpts = rollup.__getFakeBundle().input;
-            expect(inputOpts).toEqual(expectedResponse);
-        });
-    });
-
-    it('should handle original config for entry', () => {
-        const config = {
-            bundles: [{
-                entry: 'source/test.txt',
-                output: [{
-                    file: 'public/test.txt'
-                }]
-            }]
-        };
-        const expectedResponse = {
-            input: 'source/test.txt',
-            plugins: []
-        };
-        return skeletorRollup().run(config, options).then(() => {
-            const inputOpts = rollup.__getFakeBundle().input;
-            expect(inputOpts).toEqual(expectedResponse);
-        });
-    });
-
-    describe('rollup plugins', () => {
-        it('should create array of plugins', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/test.txt'
-                    },
-                    output: [{
-                        file: 'public/test.txt'
-                    }]
-                }],
-                rollupPlugins: [
-                    {
-                        module: require('./__mocks__/rollup-plugin')
-                    },
-                    {
-                        module: require('./__mocks__/rollup-plugin')
-                    }
-                ]
-            };
-            const expectedResponse = {
-                input: 'source/test.txt',
-                plugins: ['rollup-plugin', 'rollup-plugin']
-            };
-            return skeletorRollup().run(config, options).then(() => {
-                const inputOpts = rollup.__getFakeBundle().input;
-                expect(inputOpts).toEqual(expectedResponse);
-            });
-        });
-
-        it('should default plugin config to empty object', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/test.txt'
-                    },
-                    output: [{
-                        file: 'public/test.txt'
-                    }]
-                }],
-                rollupPlugins: [
-                    {
-                        module: require('./__mocks__/rollup-plugin')
-                    }
-                ]
-            };
-            const mockPlugin = require('./__mocks__/rollup-plugin');
-
-            return skeletorRollup().run(config, options).then(() => {
-                expect(mockPlugin.__getConfig()).toEqual({});
-            });
-        });
-
-        it('should call plugin with passed in config', () => {
-            const expectedResponse = {
-                prop: 'test'
-            };
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/test.txt'
-                    },
-                    output: [{
-                        file: 'public/test.txt'
-                    }]
-                }],
-                rollupPlugins: [
-                    {
-                        module: require('./__mocks__/rollup-plugin'),
-                        pluginConfig: expectedResponse
-                    }
-                ]
-            };
-            const mockPlugin = require('./__mocks__/rollup-plugin');
-
-            return skeletorRollup().run(config, options).then(() => {
-                expect(mockPlugin.__getConfig()).toEqual(expectedResponse);
-            });
-        });
-    });
-
-
-    it('should create output options', () => {
-        const config = {
-            bundles: [{
-                input: {
-                    entry: 'source/test.txt'
-                },
-                output: [{
-                    file: 'public/test.txt',
-                    format: 'iffe'
-                }]
-            }]
-        };
-        const expectedResponse = [{
-            file: 'public/test.txt',
-            format: 'iffe'
-        }];
-        return skeletorRollup().run(config, options).then(() => {
-            const outputOpts = rollup.__getFakeBundle().output;
-            expect(outputOpts).toEqual(expectedResponse);
-        });
-    });
-
-    it('should default format to "es"', () => {
-        const config = {
-            bundles: [{
-                input: {
-                    entry: 'source/test.txt'
-                },
-                output: [{
-                    file: 'public/test.txt'
-                }]
-            }]
-        };
-        const expectedResponse = [{
-            file: 'public/test.txt',
-            format: 'es'
-        }];
-        return skeletorRollup().run(config, options).then(() => {
-            const outputOpts = rollup.__getFakeBundle().output;
-            expect(outputOpts).toEqual(expectedResponse);
-        });
-    });
-
-    it('should log when bundles are complete', () => {
-        const config = {
-            bundles: [{
-                input: {
-                    entry: 'source/test.txt'
-                },
-                output: [{
-                    file: 'public/test.txt'
-                }]
-            }]
-        };
-        const expectedResponse = {
-            status: 'complete'
-        };
-        return skeletorRollup().run(config, options).then(resp => {
-            expect(logSpy).toHaveBeenCalledTimes(1);
-            expect(logSpy).toHaveBeenCalledWith('1 bundle complete.');
-            expect(resp).toEqual(expectedResponse);
-        });
-    });
-
-    it('should handle buildBundle error gracefully', () => {
-        const config = {
-            bundles: [{
-                input: {
-                    entry: 'source/test.txt'
-                },
-                output: [{
-                    file: 'error'
-                }]
+            output: [{
+                file: 'error'
             }]
         };
         const errMessage = 'Error: Could not resolve entry (error)';
-        return skeletorRollup().run(config, options).catch(err => {
+        try {
+            await skeletorRollup().run(config, options);
+        } catch (err) {
             expect(err).toEqual(errMessage);
-        });
+        }
+    });
+});
+
+describe('Rollup should receive the correct input options', () => {
+
+    it('for a single input/output set', async () => {
+        const config = {
+            input: 'source/test.txt',
+            output: [{
+                file: 'public/test.txt'
+            }],
+            experimentalCodeSplitting: true,
+            plugins: [fakeRollupPlugin(), fakeRollupPlugin()]
+        };
+        const expectedInputOptions = {
+            input: 'source/test.txt',
+            experimentalCodeSplitting: true,
+            plugins: ['rollup-plugin', 'rollup-plugin']
+        };
+
+        await skeletorRollup().run(config, options);
+        expect(rollup.rollup).toHaveBeenCalledTimes(1);
+        expect(rollup.rollup).toHaveBeenCalledWith(expectedInputOptions);
     });
 
-    describe('output', () => {
-        it('should handle one output configuration', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/entry.js'
-                    },
-                    output: [{
-                        file: 'dist/main-bundle2.js',
-                        format: 'iife'
-                    }]
+    it('for multiple input/output sets', async () => {
+        const config = [
+            {
+                input: 'source/test1.txt',
+                output: [{
+                    file: 'public/test1.txt'
+                }],
+                experimentalCodeSplitting: true,
+                plugins: [fakeRollupPlugin(), fakeRollupPlugin()]
+            },
+            {
+                input: 'source/test2.txt',
+                output: [{
+                    file: 'public/test2.txt'
                 }]
-            };
+            }
+        ];
 
-            const expectedResponse = [
+        const expectedInputOptions1 = {
+            input: 'source/test1.txt',
+            experimentalCodeSplitting: true,
+            plugins: ['rollup-plugin', 'rollup-plugin']
+        };
+
+        const expectedInputOptions2 = {
+            input: 'source/test2.txt',
+            plugins: []
+        };
+
+        await skeletorRollup().run(config, options);
+        expect(rollup.rollup).toHaveBeenCalledTimes(2);
+        expect(rollup.rollup).toHaveBeenCalledWith(expectedInputOptions1);
+        expect(rollup.rollup).toHaveBeenCalledWith(expectedInputOptions2);
+    });
+
+    it('for an array of inputs', async () => {
+        const config = {
+            input: ['source/test1.txt', 'source/test2.txt'],
+            output: [{
+                file: 'public/test.txt'
+            }],
+            experimentalCodeSplitting: true,
+            plugins: [fakeRollupPlugin(), fakeRollupPlugin()]
+        };
+        const expectedInputOptions = {
+            input: ['source/test1.txt', 'source/test2.txt'],
+            experimentalCodeSplitting: true,
+            plugins: ['rollup-plugin', 'rollup-plugin']
+        };
+
+        await skeletorRollup().run(config, options);
+        expect(rollup.rollup).toHaveBeenCalledTimes(1);
+        expect(rollup.rollup).toHaveBeenCalledWith(expectedInputOptions);
+    });
+});
+
+describe('Rollup should receive the correct output options', () => {
+    it('for a single input/output set', async () => {
+        const config = {
+            input: 'source/test.txt',
+            output: {
+                file: 'public/test.txt',
+                format: 'es'
+            }
+        };
+        const expectedOutputOptions = {
+            file: 'public/test.txt',
+            format: 'es'
+        };
+
+        await skeletorRollup().run(config, options);
+
+        const write = rollup.__getFakeBundle().write;
+  
+        expect(write).toHaveBeenCalledTimes(1);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions);
+    });
+
+    it('for a single input/output set with multiple outputs', async () => {
+        const config = {
+            input: 'source/test.txt',
+            output: [
                 {
-                    file: 'dist/main-bundle2.js',
-                    format: 'iife'
-                }
-            ];
-            return skeletorRollup().run(config, options).then(() => {
-                const inputOpts = rollup.__getFakeBundle().output;
-                expect(inputOpts).toEqual(expectedResponse);
-            });
-
-        });
-
-        it('should handle output as object', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/entry.js'
-                    },
-                    output: {
-                        file: 'dist/main-bundle2.js',
-                        format: 'iife'
-                    }
-                }]
-            };
-
-            const expectedResponse = [
-                {
-                    file: 'dist/main-bundle2.js',
-                    format: 'iife'
-                }
-            ];
-            return skeletorRollup().run(config, options).then(() => {
-                const inputOpts = rollup.__getFakeBundle().output;
-                expect(inputOpts).toEqual(expectedResponse);
-            });
-        });
-
-        it('should handle multiple output configurations', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/entry.js'
-                    },
-                    output: [
-                        {
-                            file: 'dist/main-bundle.js'
-                        },
-                        {
-                            file: 'dist/main-bundle2.js',
-                            format: 'iife'
-                        }
-                    ]
-                }]
-            };
-
-            const expectedResponse = [
-                {
-                    file: 'dist/main-bundle.js',
+                    file: 'public/test.txt',
                     format: 'es'
+                },
+                {
+                    file: 'public/test-iife.txt',
+                    format: 'iife'
+                }
+            ]
+        };
+        const expectedOutputOptions1 = {
+            file: 'public/test.txt',
+            format: 'es'
+        };
+
+        const expectedOutputOptions2 = {
+            file: 'public/test-iife.txt',
+            format: 'iife'
+        };
+
+
+        await skeletorRollup().run(config, options);
+
+        const write = rollup.__getFakeBundle().write;
+  
+        expect(write).toHaveBeenCalledTimes(2);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions1);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions2);
+    });
+
+    it('for multiple input/output sets', async () => {
+        const config = [
+            {
+                input: 'source/test1.txt',
+                output: {
+                    file: 'public/test1.txt',
+                    format: 'es'
+                }
+            },
+            {
+                input: 'source/test2.txt',
+                output: {
+                    file: 'public/test2.txt',
+                    format: 'es'
+                }
+            }
+        ];
+        const expectedOutputOptions1 = {
+            file: 'public/test1.txt',
+            format: 'es'
+        };
+
+        const expectedOutputOptions2 = {
+            file: 'public/test2.txt',
+            format: 'es'
+        };
+
+        await skeletorRollup().run(config, options);
+
+        const write = rollup.__getFakeBundle().write;
+  
+        expect(write).toHaveBeenCalledTimes(2);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions1);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions2);
+    });
+
+    it('for an array of inputs', async () => {
+        const config = {
+            input: ['source/test.txt', 'source/test2.txt'],
+            output: [
+                {
+                    dir: 'public',
+                    format: 'es'
+                },
+                {
+                    dir: 'public/no-modules',
+                    format: 'iife'
+                }
+            ]
+        };
+        const expectedOutputOptions1 = {
+            dir: 'public',
+            format: 'es'
+        };
+
+        const expectedOutputOptions2 = {
+            dir: 'public/no-modules',
+            format: 'iife'
+        };
+
+        await skeletorRollup().run(config, options);
+
+        const write = rollup.__getFakeBundle().write;
+
+        expect(write).toHaveBeenCalledTimes(2);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions1);
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions2);
+    });
+
+    it('if no output format is specified', async () => {
+        const config = {
+            input: 'source/test.txt',
+            output: [{
+                file: 'public/test.txt'
+            }]
+        };
+        const expectedOutputOptions = {
+            file: 'public/test.txt',
+            format: 'es'
+        };
+
+        await skeletorRollup().run(config, options);
+
+        const write = rollup.__getFakeBundle().write;
+  
+        expect(write).toHaveBeenCalledWith(expectedOutputOptions);
+    });
+});
+
+describe('a completion message should be logged', () => {
+    it('when bundle building is complete', async () => {
+        const config = {
+            input: 'source/test.txt',
+            output: [{
+                file: 'public/test.txt'
+            }]
+        };
+        const expectedStatusObject = {
+            status: 'complete'
+        };
+        
+        const statusObj = await skeletorRollup().run(config, options);
+        expect(logSpy).toHaveBeenCalledTimes(2);
+        expect(logSpy).toHaveBeenCalledWith('1 bundle built.');
+        expect(statusObj).toEqual(expectedStatusObject);
+    });
+
+    it('with the correct number of built bundles', async () => {
+        const config = {
+            input: 'source/entry.js',
+            output: [
+                {
+                    file: 'dist/main-bundle.js'
                 },
                 {
                     file: 'dist/main-bundle2.js',
                     format: 'iife'
                 }
-            ];
-            return skeletorRollup().run(config, options).then(() => {
-                const inputOpts = rollup.__getFakeBundle().output;
-                expect(inputOpts).toEqual(expectedResponse);
-            });
-        });
+            ]
+        };
 
-        it('should log correct number of bundles', () => {
-            const config = {
-                bundles: [{
-                    input: {
-                        entry: 'source/entry.js'
-                    },
-                    output: [
-                        {
-                            file: 'dist/main-bundle.js'
-                        },
-                        {
-                            file: 'dist/main-bundle2.js',
-                            format: 'iife'
-                        }
-                    ]
-                }]
-            };
-
-            return skeletorRollup().run(config, options).then(() => {
-                expect(logSpy).toHaveBeenCalledTimes(1);
-                expect(logSpy).toHaveBeenCalledWith('2 bundles complete.');
-            });
-        });
+        await skeletorRollup().run(config, options);
+        expect(logSpy).toHaveBeenCalledTimes(3);
+        expect(logSpy).toHaveBeenCalledWith('2 bundles built.');
     });
-
 });

--- a/index.test.js
+++ b/index.test.js
@@ -33,6 +33,28 @@ describe('An error should be thrown', () => {
         }
     });
 
+    it('if no input is defined', async () => {
+        const config = { output: { file: 'dist/test.txt'} };
+        const expectedErrorMessage = 'Error: Configuration does not have input and output properties.';
+        
+        try {
+            await skeletorRollup().run(config, options);
+        } catch(e) {
+            expect(e).toEqual(expectedErrorMessage);
+        }
+    });
+
+    it('if no output is defined', async () => {
+        const config = { input: 'source/test.txt' };
+        const expectedErrorMessage = 'Error: Configuration does not have input and output properties.';
+        
+        try {
+            await skeletorRollup().run(config, options);
+        } catch(e) {
+            expect(e).toEqual(expectedErrorMessage);
+        }
+    });
+
     it('if a bundle fails to write', async () => {
         const config = {
             input: 'source/test.txt',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-rollup",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -30,9 +30,9 @@
             "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
         },
         "@types/node": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.1.tgz",
-            "integrity": "sha512-IsX9aDHDzJohkm3VCDB8tkzl5RQ34E/PFA29TQk6uDGb7Oc869ZBtmdKVDBzY3+h9GnXB8ssrRXEPVZrlIOPOw=="
+            "version": "10.12.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
+            "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
         },
         "abab": {
             "version": "1.0.4",
@@ -4767,9 +4767,9 @@
             }
         },
         "rollup": {
-            "version": "0.60.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.60.1.tgz",
-            "integrity": "sha512-LujiS7PH8DwKAphB2ldaSEF1EX9hWY9w+mct2b4DczC8tvn7qwmr9ZFLtM9IT7gPFYlmS8O1JdiLT/aEiBEcsA==",
+            "version": "0.66.6",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.66.6.tgz",
+            "integrity": "sha512-J7/SWanrcb83vfIHqa8+aVVGzy457GcjA6GVZEnD0x2u4OnOd0Q1pCrEoNe8yLwM6z6LZP02zBT2uW0yh5TqOw==",
             "requires": {
                 "@types/estree": "0.0.39",
                 "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-rollup",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "A Skeletor plugin to bundle Javascript modules.",
     "main": "index.js",
     "scripts": {
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "path": "^0.12.7",
-        "rollup": "^0.60.1"
+        "rollup": "^0.66.6"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
This originally was an effort to include support for Rollup's code-splitting feature. That led to refactoring this plugin's configuration structure to mimic [the standard Rollup configuration structure](https://rollupjs.org/guide/en#configuration-files).
So there ended up being a fair amount of code refactoring (and unit test refactoring) to get this plugin working with the new configuration structure.