### PR TITLE
fixed bundle writes so that they happen in parallel

### DIFF
--- a/__mocks__/rollup.js
+++ b/__mocks__/rollup.js
@@ -11,12 +11,19 @@ function write(outputOpts) {
         return Promise.reject('Error: Could not resolve entry (error)');
     }
 
-    return Promise.resolve({
-        output: {
-            bundle: {
-                fileName: 'bundle.js'
+    //Writing a bundle with code splitting produces a different response structure
+    if(outputOpts.dir) {
+        return Promise.resolve({
+            output: {
+                bundle: {
+                    fileName: 'bundle.js'
+                }
             }
-        }
+        });
+    }
+
+    return Promise.resolve({
+        fileName: 'bundle.js'
     });
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,3 @@
+module.exports = {
+    flattenArray: arr => arr.reduce((acc, val) => acc.concat(val), [])
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deg-skeletor/plugin-rollup",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A Skeletor plugin to bundle Javascript modules.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Fixed a couple things here regarding the writing of a bundle to a file:

1) If a bundle has multiple outputs (i.e., the main bundle outputs to main-bundle.js and main-bundle-nomodule.js), the writing of those output files cannot happen in parallel. They need to happen sequentially, so that the bundle is not trying to write to multiple files at the same time.

2) If a bundle has code splitting enabled, the response from a bundle.write() has a different structure than if code splitting is not enabled. I updated the bundle logging code to account for these discrepancies.